### PR TITLE
Adding exponential backoff to blimp eval 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ baselines/
 # outputs from running scripts
 .out
 .err
+
+# filtered data 
+filter-data/

--- a/babylm_eval.py
+++ b/babylm_eval.py
@@ -88,6 +88,7 @@ if __name__ == "__main__":
             try: 
                 accuracies[task_title] = accuracy_on_task(task, eval_model, template,
                             args.num_fewshot)
+                _completed_task = True
             except ValueError as e: 
                 if _task_sleep_time > 64:
                     raise ValueError(f"Failed to run eval task after 64 seconds - Exception: {e}")


### PR DESCRIPTION
Sometimes processes can interfere with each other - something to do with the datasets shared memory objects; and multiple files wanting to access the same file. This ensure that if there is a problem we get a couple of attempts  